### PR TITLE
Another Large Update!

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -6,7 +6,7 @@ loader_version=0.12.6
 #Mod properties
 mod_version=1.2.0-rc1
 maven_group=io.github.jamalam360
-archives_base_name=notify
+archives_base_name=notify+dev
 #Dependencies
 fabric_api_version=0.43.1+1.18
 mod_menu_version=3.0.0

--- a/src/main/java/io/github/jamalam360/notify/NotifyModInit.java
+++ b/src/main/java/io/github/jamalam360/notify/NotifyModInit.java
@@ -88,7 +88,7 @@ public class NotifyModInit implements ModInitializer {
         statistics = new NotifyStatistics((int) (System.currentTimeMillis() - startTime));
         dumpInfoOnNextLaunchIfEnabled();
 
-        NotifyLogger.info(false, "Notify has %s percent coverage of mods", statistics.getPercentageCoverage());
+        NotifyLogger.info(false, "Notify has %s percent coverage of mods", Math.round(NotifyModInit.statistics.getPercentageCoverage() * 100) / 100D);
         NotifyLogger.info(false, "Notify took %d ms to resolve versions", statistics.getResolveTime());
     }
 
@@ -104,8 +104,7 @@ public class NotifyModInit implements ModInitializer {
     }
 
     private void dumpInfoOnNextLaunchIfEnabled() {
-        if (getConfig().dumpInfoOnNextLaunch) {
-            getConfig().dumpInfoOnNextLaunch = false;
+        if (getConfig().dumpInfoOnLaunch) {
             NotifyLogger.info(false, "Dumping debug info to file...");
             DebugFileWriter.write();
         }

--- a/src/main/java/io/github/jamalam360/notify/NotifyStatistics.java
+++ b/src/main/java/io/github/jamalam360/notify/NotifyStatistics.java
@@ -1,3 +1,27 @@
+/*
+ * The MIT License (MIT)
+ *
+ * Copyright (c) 2021 Jamalam360
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+
 package io.github.jamalam360.notify;
 
 import io.github.jamalam360.notify.resolver.NotifyVersionChecker;

--- a/src/main/java/io/github/jamalam360/notify/mixin/TitleScreenMixin.java
+++ b/src/main/java/io/github/jamalam360/notify/mixin/TitleScreenMixin.java
@@ -65,7 +65,7 @@ public abstract class TitleScreenMixin extends Screen {
             drawStringWithShadow(
                     matrices,
                     this.textRenderer,
-                    "Notify Coverage: " + NotifyModInit.statistics.getPercentageCoverage() + "%",
+                    "Notify Coverage: " + Math.round(NotifyModInit.statistics.getPercentageCoverage() * 100) / 100D + "%",
                     3,
                     3,
                     16777215 | MathHelper.ceil(this.doBackgroundFade ? MathHelper.clamp(

--- a/src/main/java/io/github/jamalam360/notify/resolver/NotifyVersionChecker.java
+++ b/src/main/java/io/github/jamalam360/notify/resolver/NotifyVersionChecker.java
@@ -26,10 +26,7 @@ package io.github.jamalam360.notify.resolver;
 
 import io.github.jamalam360.notify.NotifyErrorHandler;
 import io.github.jamalam360.notify.NotifyLogger;
-import io.github.jamalam360.notify.resolver.api.CurseForgeApiResolver;
-import io.github.jamalam360.notify.resolver.api.GradlePropertiesResolver;
-import io.github.jamalam360.notify.resolver.api.JsonFileResolver;
-import io.github.jamalam360.notify.resolver.api.ModrinthApiResolver;
+import io.github.jamalam360.notify.resolver.api.*;
 import io.github.jamalam360.notify.util.Utils;
 import net.fabricmc.loader.api.FabricLoader;
 import net.fabricmc.loader.api.ModContainer;
@@ -56,6 +53,7 @@ public class NotifyVersionChecker {
         RESOLVERS.add(new GradlePropertiesResolver());
         RESOLVERS.add(new ModrinthApiResolver());
         RESOLVERS.add(new CurseForgeApiResolver());
+        RESOLVERS.add(new NonSpecifiedGradlePropertiesResolver());
 
         try {
             unsupportedVersion = Version.parse("0.0.0");

--- a/src/main/java/io/github/jamalam360/notify/resolver/api/GradlePropertiesResolver.java
+++ b/src/main/java/io/github/jamalam360/notify/resolver/api/GradlePropertiesResolver.java
@@ -40,7 +40,7 @@ import java.util.regex.Pattern;
  * @author Jamalam360
  */
 public class GradlePropertiesResolver implements VersionResolver {
-    private static final String REGEX_BASE = "{property_name}\\s*=\\s*(\\d+\\.\\d+\\.\\d+)";
+    private static final String REGEX_BASE = "^\\s*{property_name}\\s*=\\s*([a-zA-Z0-9.+-]*)";
 
     @Override
     public boolean canResolve(ModMetadata metadata) {
@@ -51,7 +51,7 @@ public class GradlePropertiesResolver implements VersionResolver {
     @Override
     public Version resolveLatestVersion(ModMetadata metadata, String minecraftVersion) throws VersionParsingException, IOException {
         URL url = new URL(metadata.getCustomValue("notify_gradle_properties_url").getAsString());
-        Pattern p = Pattern.compile(REGEX_BASE.replace("{property_name}", metadata.getCustomValue("notify_gradle_properties_key").getAsString()));
+        Pattern p = Pattern.compile(REGEX_BASE.replace("{property_name}", metadata.getCustomValue("notify_gradle_properties_key").getAsString()), Pattern.MULTILINE);
         Matcher matcher = p.matcher(IOUtils.toString(url.openStream(), Charset.defaultCharset()));
         matcher.find();
         return Version.parse(matcher.group(1));

--- a/src/main/java/io/github/jamalam360/notify/resolver/api/NonSpecifiedGradlePropertiesResolver.java
+++ b/src/main/java/io/github/jamalam360/notify/resolver/api/NonSpecifiedGradlePropertiesResolver.java
@@ -1,0 +1,95 @@
+/*
+ * The MIT License (MIT)
+ *
+ * Copyright (c) 2021 Jamalam360
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+
+package io.github.jamalam360.notify.resolver.api;
+
+import io.github.jamalam360.notify.NotifyModInit;
+import io.github.jamalam360.notify.resolver.VersionResolver;
+import io.github.jamalam360.notify.util.Utils;
+import net.fabricmc.loader.api.Version;
+import net.fabricmc.loader.api.VersionParsingException;
+import net.fabricmc.loader.api.metadata.ModMetadata;
+import org.apache.commons.io.IOUtils;
+
+import java.io.IOException;
+import java.net.URL;
+import java.nio.charset.Charset;
+import java.util.HashMap;
+import java.util.Map;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+
+/**
+ * @author Jamalam360
+ */
+public class NonSpecifiedGradlePropertiesResolver implements VersionResolver {
+    private static final String REGEX_BASE = "^\\s*{property_name}\\s*=\\s*([a-zA-Z0-9.+-]*)";
+    private static final String[] COMMON_KEYS = {"mod_version", "version"};
+    private static final String[] COMMON_BRANCHES = {"main", "master"};
+
+    private final Map<String, Version> versionModIdCache = new HashMap<>();
+
+    @Override
+    public boolean canResolve(ModMetadata metadata) {
+        try {
+            if (!NotifyModInit.getConfig().enableNonSpecifiedGradleProperties) return false;
+        } catch (RuntimeException ignored) { //Thrown when config is not loaded because we are running a test
+        }
+
+        String ghUrl = Utils.getContactWithContent(metadata.getContact(), "github");
+
+        if (ghUrl.equals("")) return false;
+        String[] urlComponents = ghUrl.split("/");
+
+        for (String branch : COMMON_BRANCHES) {
+            String urlName = "https://raw.githubusercontent.com/" + urlComponents[3] + "/" + urlComponents[4] + "/" + branch + "/" + "gradle.properties";
+
+            try {
+                URL url = new URL(urlName);
+                String gradlePropertiesContent = IOUtils.toString(url, Charset.defaultCharset());
+
+                for (String key : COMMON_KEYS) {
+                    try {
+                        Pattern p = Pattern.compile(REGEX_BASE.replace("{property_name}", key), Pattern.MULTILINE);
+                        Matcher m = p.matcher(gradlePropertiesContent);
+                        if (m.find()) {
+                            versionModIdCache.put(metadata.getId(), Version.parse(m.group(1)));
+                            return true;
+                        }
+                    } catch (IllegalStateException | IllegalArgumentException e) {
+                        return false;
+                    }
+                }
+            } catch (Exception ignored) {
+            }
+        }
+
+        return false;
+    }
+
+    @Override
+    public Version resolveLatestVersion(ModMetadata metadata, String minecraftVersion) throws VersionParsingException, IOException {
+        return versionModIdCache.get(metadata.getId());
+    }
+}

--- a/src/main/resources/assets/notify/lang/en_us.json
+++ b/src/main/resources/assets/notify/lang/en_us.json
@@ -13,7 +13,12 @@
   "text.autoconfig.notify/notify_config.option.renderMainMenuText": "Render 'Notify Coverage' Text",
   "text.autoconfig.notify/notify_config.option.renderMainMenuText.@Tooltip": "Enable the tooltip that tells you the % support of Notify in your pack",
 
-  "text.autoconfig.notify/notify_config.option.dumpInfoOnNextLaunch": "Dump Info On Next Launch",
-  "text.autoconfig.notify/notify_config.option.dumpInfoOnNextLaunch.@Tooltip[0]": "Enable dumping of debug information on the next launch.",
-  "text.autoconfig.notify/notify_config.option.dumpInfoOnNextLaunch.@Tooltip[1]": "This will only affect the next launch."
+  "text.autoconfig.notify/notify_config.option.dumpInfoOnLaunch": "Dump Info On Launch",
+  "text.autoconfig.notify/notify_config.option.dumpInfoOnLaunch.@Tooltip[0]": "Enable dumping of debug information on launch.",
+  "text.autoconfig.notify/notify_config.option.dumpInfoOnLaunch.@Tooltip[1]": "This will significantly slow down your game launch.",
+
+  "text.autoconfig.notify/notify_config.option.enableNonSpecifiedGradleProperties": "Enabled Non-Specified Gradle",
+  "text.autoconfig.notify/notify_config.option.enableNonSpecifiedGradleProperties.@Tooltip[0]": "Enable fetching of mod versions from gradle.properties",
+  "text.autoconfig.notify/notify_config.option.enableNonSpecifiedGradleProperties.@Tooltip[1]": "files that aren't specified in by the author. This",
+  "text.autoconfig.notify/notify_config.option.enableNonSpecifiedGradleProperties.@Tooltip[2]": "could cause false positives/negatives with some mods."
 }

--- a/src/test/java/io/github/jamalam360/notify/test/GradlePropertiesTests.java
+++ b/src/test/java/io/github/jamalam360/notify/test/GradlePropertiesTests.java
@@ -48,7 +48,7 @@ public class GradlePropertiesTests {
     @Test
     public void testResolveLatestVersionNormal() throws Exception {
         assertEquals("1.1.0", resolver.resolveLatestVersion(test1, "1.16.5").getFriendlyString()); // Ideal conditions
-        assertEquals("1.1.0", resolver.resolveLatestVersion(test5, "1.16.5").getFriendlyString()); // Different version key
+        assertEquals("1.1.0+rc1", resolver.resolveLatestVersion(test5, "1.16.5").getFriendlyString()); // Different version key
     }
 
     /**
@@ -57,7 +57,7 @@ public class GradlePropertiesTests {
     @Test
     public void testResolveLatestVersionVariedMinecraft() throws Exception {
         assertEquals("1.1.0", resolver.resolveLatestVersion(test1, "1.100.1000").getFriendlyString()); // Invalid Minecraft version shouldn't change output
-        assertEquals("1.1.0", resolver.resolveLatestVersion(test5, "").getFriendlyString()); // Invalid Minecraft version shouldn't change output
+        assertEquals("1.1.0+rc1", resolver.resolveLatestVersion(test5, "").getFriendlyString()); // Invalid Minecraft version shouldn't change output
     }
 
     /**
@@ -68,6 +68,6 @@ public class GradlePropertiesTests {
         assertEquals("1.1.0", resolver.resolveLatestVersion(test2, "1.16.5").getFriendlyString()); // gradle.properties has spaces inbetween key values
         assertEquals("1.1.0", resolver.resolveLatestVersion(test3, "1.16.5").getFriendlyString()); // gradle.properties leading spaces
         assertEquals("1.1.0", resolver.resolveLatestVersion(test4, "1.16.5").getFriendlyString()); // gradle.properties trailing spaces
-        assertEquals("1.1.0", resolver.resolveLatestVersion(test6, "1.16.5").getFriendlyString()); // gradle.properties has all of the above
+        assertEquals("1.1.0-build+1", resolver.resolveLatestVersion(test6, "1.16.5").getFriendlyString()); // gradle.properties has all of the above
     }
 }

--- a/src/test/java/io/github/jamalam360/notify/test/NonSpecifiedGradlePropertiesTests.java
+++ b/src/test/java/io/github/jamalam360/notify/test/NonSpecifiedGradlePropertiesTests.java
@@ -22,28 +22,29 @@
  * THE SOFTWARE.
  */
 
-package io.github.jamalam360.notify.config;
+package io.github.jamalam360.notify.test;
 
-import me.shedaniel.autoconfig.ConfigData;
-import me.shedaniel.autoconfig.annotation.Config;
-import me.shedaniel.autoconfig.annotation.ConfigEntry;
+import io.github.jamalam360.notify.resolver.api.NonSpecifiedGradlePropertiesResolver;
+import io.github.jamalam360.notify.test.metadata.SourcesModMetadata;
+import net.fabricmc.loader.api.metadata.ModMetadata;
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
 
 /**
  * @author Jamalam360
  */
+public class NonSpecifiedGradlePropertiesTests {
+    private final NonSpecifiedGradlePropertiesResolver resolver = new NonSpecifiedGradlePropertiesResolver();
 
-@Config(name = "notify/notify_config")
-public class ModConfig implements ConfigData {
-    @ConfigEntry.Gui.Tooltip
-    public boolean verboseLogging = false;
-    @ConfigEntry.Gui.Tooltip
-    public boolean displayUpdatedBadge = true;
-    @ConfigEntry.Gui.Tooltip
-    public boolean displayUnsupportedBadge = false;
-    @ConfigEntry.Gui.Tooltip
-    public boolean renderMainMenuText = true;
-    @ConfigEntry.Gui.Tooltip(count = 2)
-    public boolean dumpInfoOnLaunch = false;
-    @ConfigEntry.Gui.Tooltip(count = 3)
-    public boolean enableNonSpecifiedGradleProperties = true;
+    private final ModMetadata test1 = new SourcesModMetadata("https://github.com/JamCoreModding/Notify");
+
+    /**
+     * Check whether everything works under ideal conditions
+     */
+    @Test
+    public void testResolveLatestVersionNormal() throws Exception {
+        resolver.canResolve(test1); // Needed to populate the cache
+        assertEquals("1.2.0-rc1", resolver.resolveLatestVersion(test1, "1.16.5").getFriendlyString()); // Ideal conditions
+    }
 }

--- a/src/test/java/io/github/jamalam360/notify/test/metadata/SourcesModMetadata.java
+++ b/src/test/java/io/github/jamalam360/notify/test/metadata/SourcesModMetadata.java
@@ -1,0 +1,133 @@
+/*
+ * The MIT License (MIT)
+ *
+ * Copyright (c) 2021 Jamalam360
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+
+package io.github.jamalam360.notify.test.metadata;
+
+import net.fabricmc.loader.api.Version;
+import net.fabricmc.loader.api.metadata.*;
+
+import java.util.Collection;
+import java.util.Map;
+import java.util.Optional;
+
+/**
+ * @author Jamalam360
+ */
+public record SourcesModMetadata(String sources) implements ModMetadata {
+    @Override
+    public ContactInformation getContact() {
+        return new ContactInformation() {
+            @Override
+            public Optional<String> get(String key) {
+                return Optional.of(SourcesModMetadata.this.sources());
+            }
+
+            @Override
+            public Map<String, String> asMap() {
+                return Map.of("sources", SourcesModMetadata.this.sources());
+            }
+        };
+    }
+
+    @Override
+    public boolean containsCustomValue(String key) {
+        return false;
+    }
+
+    @Override
+    public boolean containsCustomElement(String key) {
+        return false;
+    }
+
+    @Override
+    public CustomValue getCustomValue(String key) {
+        return null;
+    }
+
+    @Override
+    public String getType() {
+        return null;
+    }
+
+    @Override
+    public String getId() {
+        return null;
+    }
+
+    @Override
+    public Collection<String> getProvides() {
+        return null;
+    }
+
+    @Override
+    public Version getVersion() {
+        return null;
+    }
+
+    @Override
+    public ModEnvironment getEnvironment() {
+        return null;
+    }
+
+    @Override
+    public Collection<ModDependency> getDependencies() {
+        return null;
+    }
+
+    @Override
+    public String getName() {
+        return null;
+    }
+
+    @Override
+    public String getDescription() {
+        return null;
+    }
+
+    @Override
+    public Collection<Person> getAuthors() {
+        return null;
+    }
+
+    @Override
+    public Collection<Person> getContributors() {
+        return null;
+    }
+
+    @Override
+    public Collection<String> getLicense() {
+        return null;
+    }
+
+    @Override
+    public Optional<String> getIconPath(int size) {
+        return Optional.empty();
+    }
+
+    @Override
+    public Map<String, CustomValue> getCustomValues() {
+        return null;
+    }
+}
+


### PR DESCRIPTION
- Fixed a regex issue that meant that versions like `1.1.0-rc1` or `1.5.0+mc1.5.6` were parsed as `1.1.0` and `1.5.0` respectively.
- Added rounding to percentages
- Licensed some files that weren't licensed by the bot for some reason
- Add extra tests in GradlePropertiesTests

And finally, the big change:

- Notify can now parse `fabric.mod.json` for a GitHub URL, which it can use to try and locate a `gradle.properties` file to parse for a version. There is a config option to disable this as it could cause issues
- There are also tests for this

Fixes: #11